### PR TITLE
[chore] fix inconsistent component state updates found on LGTM.com

### DIFF
--- a/src/Element.jsx
+++ b/src/Element.jsx
@@ -200,7 +200,7 @@ class Element extends Component {
   animEnd = () => {
     const type = this.state.show ? 'enter' : 'leave';
     this.props.callBack(type);
-    this.setState({ show: this.props.show, mouseMoveType: null });
+    this.setState((_, props) => ({ show: props.show, mouseMoveType: null }));
   }
 
   animChildren = (props, style, bgElem) => {


### PR DESCRIPTION
React component state updates using `setState` may asynchronously update `this.props` and `this.state`, thus it is not safe to use either of the two when calculating the new state passed to `setState`, and instead the callback-based variant should be used instead. ([details here](https://lgtm.com/rules/1819283066/)).

*(Full disclosure: I'm part of the team behind LGTM.com)*